### PR TITLE
Return the identity like another strategies

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -67,7 +67,6 @@ export class ApiKeyStrategy extends AuthenticationBaseStrategy {
         ...params.headers,
         [headerField]: apiKey
       },
-      [entity]: apiKey,
       apiKey: true
     };
 
@@ -82,6 +81,8 @@ export class ApiKeyStrategy extends AuthenticationBaseStrategy {
         throw new NotAuthenticated("API Key has been revoked");
       }
     }
+
+    response[entity] = apiKeyData;
     return response;
   }
 


### PR DESCRIPTION
Currently feathers authentication strategies return the corresponding entity, for that it will be convenient to return the identity.